### PR TITLE
Show cassette when listing cassettes on subdirectories is broken

### DIFF
--- a/app/models/mr_video/cassette.rb
+++ b/app/models/mr_video/cassette.rb
@@ -74,6 +74,7 @@ module MrVideo
     end
 
     def self.find(name)
+      name = URI.decode(name)
       cassette_path = cassette_paths(name).first
       unless cassette_path
         raise StandardError.new("#{self.name} with name: '#{name}' not found!")

--- a/spec/models/mr_video/cassette_spec.rb
+++ b/spec/models/mr_video/cassette_spec.rb
@@ -72,4 +72,11 @@ describe MrVideo::Cassette do
     its(:size) { should == 6 }
   end # .all
 
+  describe '.find' do
+    context 'when name is from a subdirectory' do
+      let(:model) { model_class.find('test_subdirectory%2Fdummy_cassette_2') }
+      it { -> { model }.should_not raise_error }
+    end
+  end
+
 end # MrVideo::Cassette


### PR DESCRIPTION
That happens when a cassete is in a subdirectory and we click on a cassette to show details of it.

Error happens on Cassette.find(name) since name is the id and when it comes from the controller, id is URI encoded. 

This PR fixes it.

So if it is ok, could you merge it?